### PR TITLE
added exception for using tpu

### DIFF
--- a/wtfml/utils/early_stopping.py
+++ b/wtfml/utils/early_stopping.py
@@ -27,6 +27,11 @@ class EarlyStopping:
         else:
             self.val_score = -np.Inf
 
+        if self.tpu and not _xla_available:
+            raise Exception(
+                "You want to use TPUs but you dont have pytorch_xla installed"
+            )
+
     def __call__(self, epoch_score, model, model_path):
         if self.mode == "min":
             score = -1.0 * epoch_score


### PR DESCRIPTION
@abhishekkrthakur Thank you for sharing great code, notebook, youtube videos, and book! I'm learning a lot of things from you. 
In early_stopping.py, "_xla_available" is defined but not used. So I added exception code in it referring to engine.py. I hope this helps you.